### PR TITLE
Add possibility to define the file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ gulp.src("./templates/*.ejs")
 
 ## API
 
-### ejs(options)
+### ejs(options, settings)
 
 #### options
 Type: `hash`
@@ -33,6 +33,18 @@ Default: `{}`
 A hash object where each key corresponds to a variable in your template. Also you can set ejs options in this hash.
 
 For more info on `ejs` options, check the [project's documentation](https://github.com/visionmedia/ejs).
+
+#### settings
+Type: `hash`
+Default: `{ext: '.html'}`
+
+A hash object to configure the plugin.
+
+##### settings.ext
+Type: `String`
+Default: `.html`
+
+Defines the default file extension that will be appended to the filename.
 
 
 ## License

--- a/index.js
+++ b/index.js
@@ -4,11 +4,14 @@ var es = require('event-stream');
 var gutil = require('gulp-util');
 var ejs = require('ejs');
 
-module.exports = function (options) {
+module.exports = function (options, settings) {
     return es.map(function (file, cb) {
         try {
+            settings = settings || {};
+            if(!settings.ext) settings.ext = '.html';
+
             file.contents = new Buffer(ejs.render(file.contents.toString(), options));
-            file.path = gutil.replaceExtension(file.path, '.html');
+            file.path = gutil.replaceExtension(file.path, settings.ext);
             cb(null, file);
         } catch (err) {
             return cb(new Error('gulp-ejs: ' + err));

--- a/test/main.js
+++ b/test/main.js
@@ -2,7 +2,8 @@
 'use strict';
 
 var fs = require('fs'),
-should = require('should');
+should = require('should'),
+path = require('path');
 require('mocha');
 
 var gutil = require('gulp-util'),
@@ -43,7 +44,9 @@ describe('gulp-ejs', function () {
         });
 
         stream.write(srcFile);
-        stream.end();
+        String(path.extname(srcFile.path)).should.equal('.html');
+
+      stream.end();
     });
 
     it('should throw error when syntax is incorrect', function (done) {
@@ -65,4 +68,35 @@ describe('gulp-ejs', function () {
         stream.write(srcFile);
         stream.end();
     });
+
+  it('should produce correct html output with a specific file extension', function (done) {
+
+    var srcFile = new gutil.File({
+      path: 'test/fixtures/ok.ejs',
+      cwd: 'test/',
+      base: 'test/fixtures',
+      contents: fs.readFileSync('test/fixtures/ok.ejs')
+    });
+
+    var stream = ejs({ title: 'gulp-ejs' }, {ext:'.txt'});
+
+    stream.on('error', function (err) {
+      should.exist(err);
+      done(err);
+    });
+
+    stream.on('data', function (newFile) {
+
+      should.exist(newFile);
+      should.exist(newFile.contents);
+
+      String(newFile.contents).should.equal(String(expectedFile.contents));
+      done();
+    });
+
+    stream.write(srcFile);
+    String(path.extname(srcFile.path)).should.equal('.txt');
+
+    stream.end();
+  });
 });


### PR DESCRIPTION
In some scenario you may want to have the possibility to define the file extension for the output. e.g. if you want to compile javascript template to .js files. 
