### PR TITLE
Update# add auto fill filename feature to support ejs include

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,12 @@ var ejs = require('ejs');
 
 module.exports = function (options, settings) {
     settings = settings || {};
+    options = options || {};
     settings.ext = settings.ext || '.html';
 
     return es.map(function (file, cb) {
         try {
+            options.filename = options.filename || file.path;
             file.contents = new Buffer(ejs.render(file.contents.toString(), options));
             file.path = gutil.replaceExtension(file.path, settings.ext);
         } catch (err) {


### PR DESCRIPTION
Hello, I add some code to let ejs can using "include" feature.
I let it auto fill `filename` options if not specify, and ejs can find partials correctly when use `<% include _partials %>`

I also test below setting can skip "_" prefix ejs file but still provide ejs include feature.

``` js
gulp.src(["app/**/*.ejs", "!app/**/_*.ejs"])
       .pipe(ejs())
       .pipe(gulp.dest("public"))
```
