### PR TITLE
add not found handler to prevent gulp interrupt when partial not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,16 @@ var es = require('event-stream');
 var gutil = require('gulp-util');
 var ejs = require('ejs');
 
+var logPrefix = "[" + gutil.colors.blue("ejs") + "]";
+
+var notFoundHandler = function(err, file, settings) {
+    var errorMessage = "partial '" + err.path + "' not found";
+    gutil.log(logPrefix, gutil.colors.red(errorMessage));
+    file.contents = new Buffer(errorMessage); // Output error message into file
+    file.path = gutil.replaceExtension(file.path, settings.ext);
+    return file;
+}
+
 module.exports = function (options, settings) {
     settings = settings || {};
     options = options || {};
@@ -15,6 +25,10 @@ module.exports = function (options, settings) {
             file.contents = new Buffer(ejs.render(file.contents.toString(), options));
             file.path = gutil.replaceExtension(file.path, settings.ext);
         } catch (err) {
+            if(err.code === 'ENOENT') {
+                // Partial file not found, keep gulp and log error
+                return cb(null, notFoundHandler(err, file, settings));
+            }
             return cb(new gutil.PluginError('gulp-ejs', err));
         }
         cb(null, file);


### PR DESCRIPTION
I add `include` support yesterday, but when I type "wrong partial filename" and ejs will throw a error.
Now, gulp-ejs will catch this error and return PluginError and gulp interrupt.

But I think work flow interrupt by this is very not comfortable, and I didn't want to restart gulp every time.
So I add `notFoundHandler` to handle `ENOENT` error and log it to prevent gulp interrupt.
(But I am not sure this is fit gulp suggest, I just think this may improve gulp-ejs experience.)

![2014-02-22 11 21 15](https://f.cloud.github.com/assets/887984/2236897/a3c983e4-9b72-11e3-9316-152cbb304904.png)
