### PR TITLE
Fix filename always being set to the first file's path.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function (options, settings) {
             );
         }
 
-        options.filename = options.filename || file.path;
+        options.filename = file.path;
         try {
             file.contents = new Buffer(ejs.render(file.contents.toString(), options));
             file.path = gutil.replaceExtension(file.path, settings.ext);

--- a/test/main.js
+++ b/test/main.js
@@ -131,4 +131,28 @@ describe('gulp-ejs', function () {
     stream.end();
   });
 
+  it('should provide correct filenames', function (done) {
+
+    var file1 = new gutil.File({
+      path: 'foo',
+      contents: new Buffer('<%- filename -%>.html')
+    });
+
+    var file2 = new gutil.File({
+      path: 'bar',
+      contents: new Buffer('<%- filename -%>.html')
+    });
+
+    var stream = ejs();
+
+    stream.on('data', function (newFile) {
+
+      newFile.contents.toString().should.equal(newFile.path);
+      if (newFile.path == 'bar.html') done();
+    });
+
+    stream.write(file1);
+    stream.write(file2);
+    stream.end();
+  })
 });


### PR DESCRIPTION
As my test shows, filename never changes from the first, causing caching issues with ejs.
