### PR TITLE
settings.keepExt

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function (options, settings) {
         options.filename = file.path;
         try {
             file.contents = new Buffer(ejs.render(file.contents.toString(), options));
-            file.path = gutil.replaceExtension(file.path, settings.ext);
+            file.path = settings.keepExt ? file.path : gutil.replaceExtension(file.path, settings.ext);
         } catch (err) {
             this.emit('error', new gutil.PluginError('gulp-ejs', err.toString()));
         }


### PR DESCRIPTION
added option to keep original file extension

Normally, your build process looks like this:

```
  gulp.src(sources)
      .pipe(ejs({
        msg: 'Hello Gulp!'
      }).on('error', gutil.log))
```

there is no clean way to keep sources extensions (sources might contain a list of files with different extensions that you do not want to rename)