### PR TITLE
Update `ejs` to v2.2.4

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var through = require('through2');
 var gutil = require('gulp-util');
 var ejs = require('ejs');
+var eol = require('os').EOL;
 
 module.exports = function (options, settings) {
     settings = settings || {};
@@ -24,7 +25,7 @@ module.exports = function (options, settings) {
 
         options.filename = file.path;
         try {
-            file.contents = new Buffer(ejs.render(file.contents.toString(), options));
+            file.contents = new Buffer(ejs.render(file.contents.toString(), options) + eol);
             file.path = gutil.replaceExtension(file.path, settings.ext);
         } catch (err) {
             this.emit('error', new gutil.PluginError('gulp-ejs', err.toString()));

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "ejs": "^1.0.0",
+    "ejs": "^2.2.4",
     "gulp-util": "^3.0.1",
     "through2": "^1.1.1"
   },

--- a/test/main.js
+++ b/test/main.js
@@ -3,7 +3,8 @@
 
 var fs = require('fs'),
 should = require('should'),
-path = require('path');
+path = require('path'),
+eol = require('os').EOL;
 require('mocha');
 
 var gutil = require('gulp-util'),
@@ -147,7 +148,7 @@ describe('gulp-ejs', function () {
 
     stream.on('data', function (newFile) {
 
-      newFile.contents.toString().should.equal(newFile.path);
+      newFile.contents.toString().should.equal(newFile.path + eol);
       if (newFile.path == 'bar.html') done();
     });
 
@@ -210,7 +211,7 @@ describe('gulp-ejs', function () {
         should.exist(newFile.contents);
         path.extname(newFile.path).should.equal('.css')
 
-        String(newFile.contents).should.equal(fs.readFileSync('test/expected/head.css', 'utf8'));
+        String(newFile.contents).should.equal(fs.readFileSync('test/expected/head.css', 'utf8') + eol);
         done();
       });
 


### PR DESCRIPTION
The update to the v2 branch of `ejs` causes a trailing line break to be
removed from the end of a file.

This PR adds back in that line break so as to maintain a consistent
api with v1 of `gulp-ejs`.

There is currently an open issue in mde/ejs#60 that addresses the
issue of the removal of the character.

This PR can remain unmerged until mde/ejs#60 is resolved.