### PR TITLE
conform to ejs.render argument signature

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function (options, settings) {
         options.filename = file.path;
         try {
             file.contents = new Buffer(
-                ejs.render(file.contents.toString(), file.data || options)
+                ejs.render(file.contents.toString(), file.data || {}, options)
             );
             file.path = gutil.replaceExtension(file.path, settings.ext);
         } catch (err) {


### PR DESCRIPTION
by using `file.data || options`, `options` (specifically `options.filename`) were never being passed to includes and the task would fail silently. this small change employs a fixed argument signature that respects the expectations of ejs.render and ensures that options are consistently passed.