### PR TITLE
Merge options and file.data when both are passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Default: `{}`
 
 A hash object where each key corresponds to a variable in your template. Also you can set ejs options in this hash.
 
-For more info on `ejs` options, check the [project's documentation](https://github.com/visionmedia/ejs).
+For more info on `ejs` options, check the [project's documentation](https://github.com/mde/ejs).
 
-**Note:** As of `v1.2.0`, `file.data` is supported as a way of passing data into ejs. See [this](https://github.com/colynb/gulp-data#note-to-gulp-plugin-authors).
+**Note:** As of `v1.2.0`, `file.data` is supported as a way of passing data into ejs. See [this](https://github.com/colynb/gulp-data#note-to-gulp-plugin-authors). If both `file.data` and `options` are passed, they are merged (`options` works as default for ejs options and `file.data` overrides it.)
 
 #### settings
 Type: `hash`

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var through = require('through2');
 var gutil = require('gulp-util');
 var ejs = require('ejs');
+var assign = require('object-assign');
 
 module.exports = function (options, settings) {
     options = options || {};
@@ -21,7 +22,7 @@ module.exports = function (options, settings) {
             );
         }
 
-        options = file.data || options;
+        options = assign({}, options, file.data);
         options.filename = file.path;
 
         try {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "ejs": "2.5.1",
     "gulp-util": "3.0.7",
+    "object-assign": "^4.1.0",
     "through2": "2.0.1"
   },
   "devDependencies": {

--- a/test/expected/outputWithPartial.html
+++ b/test/expected/outputWithPartial.html
@@ -1,3 +1,4 @@
 <h2>gulp-ejs</h2>
 
-<h3><p>Hello rpvl!</p></h3>
+<h3><p>Hello rpvl!</p>
+</h3>

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,8 +1,0 @@
-'use strict';
-
-/**
- * Removes the line break in the given file contents.
- */
-exports.removeLineBreak = function (contents) {
-    return contents.toString().replace(/\r?\n|\r/g, '');
-};

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Removes the line break in the given file contents.
+ */
+exports.removeLineBreak = function (contents) {
+    return contents.toString().replace(/\r?\n|\r/g, '');
+};

--- a/test/main.js
+++ b/test/main.js
@@ -7,7 +7,6 @@ path = require('path');
 require('mocha');
 
 var gutil = require('gulp-util'),
-removeLineBreak = require('./helper').removeLineBreak,
 ejs = require('../');
 
 describe('gulp-ejs', function () {
@@ -124,10 +123,7 @@ describe('gulp-ejs', function () {
       should.exist(newFile);
       should.exist(newFile.contents);
 
-      var current = removeLineBreak(newFile.contents);
-      var expected = removeLineBreak(expectedFileWithPartial.contents);
-
-      current.should.equal(expected);
+      String(newFile.contents).should.equal(String(expectedFileWithPartial.contents));
       done();
     });
 
@@ -216,10 +212,7 @@ describe('gulp-ejs', function () {
           should.exist(newFile);
           should.exist(newFile.contents);
 
-          var current = removeLineBreak(newFile.contents);
-          var expected = removeLineBreak(expectedFileWithPartial.contents);
-
-          current.should.equal(expected);
+          String(newFile.contents).should.equal(String(expectedFileWithPartial.contents));
           done();
       });
 

--- a/test/main.js
+++ b/test/main.js
@@ -7,6 +7,7 @@ path = require('path');
 require('mocha');
 
 var gutil = require('gulp-util'),
+removeLineBreak = require('./helper').removeLineBreak,
 ejs = require('../');
 
 describe('gulp-ejs', function () {
@@ -123,8 +124,8 @@ describe('gulp-ejs', function () {
       should.exist(newFile);
       should.exist(newFile.contents);
 
-      var current = newFile.contents.toString().replace(/\r?\n|\r/g, '');
-      var expected = expectedFileWithPartial.contents.toString().replace(/\r?\n|\r/g, '');
+      var current = removeLineBreak(newFile.contents);
+      var expected = removeLineBreak(expectedFileWithPartial.contents);
 
       current.should.equal(expected);
       done();
@@ -159,7 +160,7 @@ describe('gulp-ejs', function () {
     stream.write(file1);
     stream.write(file2);
     stream.end();
-  })
+  });
 
   it('should support passing data with gulp-data', function (done) {
       var srcFile = new gutil.File({ path: 'test/fixtures/ok.ejs',
@@ -193,6 +194,39 @@ describe('gulp-ejs', function () {
       stream.end();
   });
 
+  it('should merge options and file.data when both are passed', function (done) {
+      var srcFile = new gutil.File({
+          path: 'test/fixtures/withpartial.ejs',
+          cwd: 'test/',
+          base: 'test/fixtures',
+          contents: fs.readFileSync('test/fixtures/withpartial.ejs')
+      });
+
+      // simulate gulp-data plugin
+      srcFile.data = { name: 'rpvl' };
+
+      var stream = ejs({ msg: 'gulp-ejs', name: 'foo' });
+
+      stream.on('error', function (err) {
+          should.exist(err);
+          done(err);
+      });
+
+      stream.on('data', function (newFile) {
+          should.exist(newFile);
+          should.exist(newFile.contents);
+
+          var current = removeLineBreak(newFile.contents);
+          var expected = removeLineBreak(expectedFileWithPartial.contents);
+
+          current.should.equal(expected);
+          done();
+      });
+
+      stream.write(srcFile);
+      stream.end();
+  });
+
   describe('with assets', function () {
     it('should templating with javascripts', function (done) {
       var srcFile = new gutil.File({
@@ -215,7 +249,7 @@ describe('gulp-ejs', function () {
 
         should.exist(newFile);
         should.exist(newFile.contents);
-        path.extname(newFile.path).should.equal('.js')
+        path.extname(newFile.path).should.equal('.js');
 
         String(newFile.contents).should.equal(fs.readFileSync('test/expected/config.js', 'utf8'));
         done();
@@ -245,7 +279,7 @@ describe('gulp-ejs', function () {
 
         should.exist(newFile);
         should.exist(newFile.contents);
-        path.extname(newFile.path).should.equal('.css')
+        path.extname(newFile.path).should.equal('.css');
 
         String(newFile.contents).should.equal(fs.readFileSync('test/expected/head.css', 'utf8'));
         done();


### PR DESCRIPTION
Hello

Thanks for the plugin.

In my team's use case, we'd like to pass both file.data and options. This PR adds the feature of merging `options` and `file.data` if both are given. I think this is a natural enhancement.
