### PR TITLE
Properly render clientside templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,9 +28,20 @@ module.exports = function (data, options, settings) {
     options.filename = file.path
 
     try {
-      file.contents = new Buffer(
-        ejs.render(file.contents.toString(), data, options)
-      )
+      if(options.client === true){
+        var name = file.basename.split(/\./)[0].toLowerCase()+(settings.suffix !== undefined ? settings.suffix : '');
+        var template = ejs.compile(file.contents.toString(), options);
+        var templateFunctionBody = template.toString().match(/function[^{]+\{([\s\S]*)\}$/)[1]+'\n}';
+        options.filename = options.filename === undefined ? file.basename : options.filename;
+        file.contents = new Buffer(
+          'if(window.templates === undefined) window.templates = {}; '+
+          'window.templates[\''+name+'\'] = '+template.toString().replace(/function anonymous\(/, 'function(')
+        )
+      } else {
+        file.contents = new Buffer(
+          ejs.render(file.contents.toString(), data, options)
+        )
+      }
 
       if (typeof settings.ext !== 'undefined') {
         file.path = gutil.replaceExtension(file.path, settings.ext)


### PR DESCRIPTION
Clientside templates will be named same as source files without extension, optionally adding `settings.suffix` to the end.
Set options.filename to `file.basename` for caching (speeds up gulp watch task when working).
New settings:
`settings.suffix` - when `options.client` is `true`, appends the string provided to the end of the generated clientside template.
Should fix issue #96