### PR TITLE
Assign settings to ejs

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = function (data, options, settings) {
     options.filename = file.path
 
     try {
+      assign(ejs, settings)
       file.contents = new Buffer(
         ejs.render(file.contents.toString(), data, options)
       )


### PR DESCRIPTION
This copies settings passes to gulp-ejs to ejs, so that you can change settings such as the delimiter and custom FileLoader.

closes #109 