### PR TITLE
Supports async rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ ejs.__EJS__.fileLoader = function () { /* custom file loader */ }
 
 **Note:** As of version 4, the exported ejs object was renamed from `ejs` to `__EJS__`.
 
+### Async rendering (requires runtime support)
+
+You can use async/await in ejs template by passing `{async: true}` in options:
+
+```javascript
+const ejs = require('gulp-ejs')
+
+async function blah() { /* async task */ }
+
+gulp.src("./templates/*.ejs")
+	.pipe(ejs({blah}, {async: true}))
+	.pipe(gulp.dest("./dist"))
+```
+
+In template, await will be used to call async functions for example: `<%= await blah() %>`
+
 ## API
 
 ### ejs(data, options)

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function render(data, options = {}) {
             'error',
             new PluginError(PLUGIN_NAME, err, { fileName: file.path })
           )
-        }).then(() => callback())
+        }).then(callback)
 
         return
       }

--- a/index.js
+++ b/index.js
@@ -21,11 +21,24 @@ function render(data, options = {}) {
     const ejsData = Object.assign({}, data, file.data)
 
     try {
-      file.contents = Buffer.from(
-        ejs.render(file.contents.toString(), ejsData, options)
-      )
+      const rendered = ejs.render(file.contents.toString(), ejsData, options)
 
-      this.push(file)
+      if (options.async && typeof rendered.then === 'function') {
+        rendered.then(rendered => {
+          file.contents = Buffer.from(rendered)
+          this.push(file)
+        }).catch(err => {
+          this.emit(
+            'error',
+            new PluginError(PLUGIN_NAME, err, { fileName: file.path })
+          )
+        }).then(() => callback())
+
+        return
+      }
+
+      file.contents = Buffer.from(rendered);
+      this.push(file);
     } catch (err) {
       this.emit(
         'error',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -104,4 +104,25 @@ describe('gulp-ejs', function() {
 
     stream.end()
   })
+
+  it('should render async ejs template', function(done) {
+    const title = () => new Promise((resolve, reject) => {
+      process.nextTick(() => resolve('gulp-ejs'))
+    })
+    const stream = ejs({ title: title }, { async: true })
+
+    stream.on('data', data => {
+      assert.strictEqual(data.contents.toString(), '<h1>gulp-ejs</h1>')
+    })
+
+    stream.on('end', done)
+
+    stream.write(
+      new Vinyl({
+        contents: Buffer.from('<h1><%= await title() %></h1>')
+      })
+    )
+
+    stream.end()
+  })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -106,6 +106,18 @@ describe('gulp-ejs', function() {
   })
 
   it('should render async ejs template', function(done) {
+    /* Skip test if async function is not supported (Node 7.5-) */
+    try {
+      /* eslint-disable-next-line no-new-func */
+      (new Function('return (async function(){}).constructor;'))()
+    } catch (e) {
+      if (e instanceof SyntaxError) {
+        this.skip()
+      } else {
+        throw e
+      }
+    }
+
     const title = () => new Promise((resolve, reject) => {
       process.nextTick(() => resolve('gulp-ejs'))
     })


### PR DESCRIPTION
I want to use async function in ejs template.
`ejs` supports async rendering since v2.6.1 (see https://github.com/mde/ejs/blob/master/CHANGELOG.md)
This PR adds support.
